### PR TITLE
removed the colonpath from the api.walk

### DIFF
--- a/examples/gorilla/main.go
+++ b/examples/gorilla/main.go
@@ -63,8 +63,6 @@ func main() {
 	router := mux.NewRouter()
 	api.Walk(func(path string, endpoint *swagger.Endpoint) {
 		h := endpoint.Handler.(http.HandlerFunc)
-		path = swag.ColonPath(path)
-
 		router.Path(path).Methods(endpoint.Method).Handler(h)
 	})
 


### PR DESCRIPTION
This path conversion is for the GIN framework. Gorilla uses the {var} convention